### PR TITLE
GTK+ version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,20 @@ nix-shell --run 'ghcid -T :main'
 nix-shell --run 'JSADDLE_WARP_PORT=8080 ghcid -T :main'
 ```
 
+## Compiling 
+
 Build JS using GHCJS:
 
 ```bash
 nix-build
 open ./result/index.html
+```
+
+Build GTK+ desktop version 
+
+```bash
+nix-build 
+./result/bin/ka
 ```
 
 ## Credits

--- a/desktop.nix
+++ b/desktop.nix
@@ -1,0 +1,4 @@
+let 
+  p = import ./project.nix { useWarp = false; };
+in 
+  p.project.ghc.reflex-stone

--- a/project.nix
+++ b/project.nix
@@ -1,4 +1,5 @@
 { system ? builtins.currentSystem
+, useWarp ? false
 }:
 let 
   gitignoreSrc = builtins.fetchTarball {
@@ -14,7 +15,7 @@ let
     inherit system;
   };
   project = reflexPlatform.project ({pkgs, ...}: {
-    useWarp = true;
+    inherit useWarp;
     withHoogle = false;
     packages = {
       reflex-stone = pkgs.lib.cleanSource (gitignoreSource ./.);


### PR DESCRIPTION
Fails to launch cleanly, due to an issue with reflex-platform (direct nixpkgs would work, though).

- [ ] Try direct nixpkgs (but only if using desktop.nix?)